### PR TITLE
Allow signing JWTs with HS256

### DIFF
--- a/jose/Header.ml
+++ b/jose/Header.ml
@@ -24,7 +24,8 @@ let empty_header =
   }
 
 let make_header ?typ (jwk : Jwk.Pub.t) =
-  { empty_header with alg = `RS256; typ; kid = Some (Jwk.Pub.get_kid jwk) }
+  let alg = match jwk with Jwk.Pub.RSA _ -> `RS256 | OCT _ -> `HS256 in
+  { empty_header with alg; typ; kid = Some (Jwk.Pub.get_kid jwk) }
 
 module Json = Yojson.Safe.Util
 

--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -55,7 +55,7 @@ module Jwk : sig
     *)
 
     val rsa_of_pub_pem : string -> (rsa, [ `Msg of string ]) result
-    (** 
+    (**
     [rsa_of_pub_pem pem] takes a public PEM as a string and returns a result a result t or a message of what went wrong.
     *)
 
@@ -151,6 +151,11 @@ module Jwk : sig
     val rsa_to_priv_pem : rsa -> (string, [ `Msg of string ]) result
     (**
     [to_priv_pem t] takes a private JWK and returns a result PEM string or a message of what went wrong.
+    *)
+
+    val oct_of_string : string -> oct
+    (**
+    [oct_of_string secret] creates a [oct] from a shared secret
     *)
 
     val to_json : t -> Yojson.Safe.t
@@ -296,7 +301,7 @@ module Jws : sig
   val sign :
     header:Header.t ->
     payload:string ->
-    Nocrypto.Rsa.priv ->
+    Jwk.Priv.t ->
     (t, [ `Msg of string ]) result
   (**
   [sign header payload priv] creates a signed JWT from [header] and [payload]
@@ -335,7 +340,7 @@ module Jwt : sig
   val sign :
     header:Header.t ->
     payload:payload ->
-    Nocrypto.Rsa.priv ->
+    Jwk.Priv.t ->
     (t, [ `Msg of string ]) result
   (**
   [sign header payload priv] creates a signed JWT from [header] and [payload]

--- a/jose/Jwk.ml
+++ b/jose/Jwk.ml
@@ -38,10 +38,8 @@ module Oct = struct
   }
 
   let oct_of_string str =
-    let key = Cstruct.of_string str in
     let k =
-      Cstruct.to_bytes key |> Bytes.to_string
-      |> Base64.encode_exn ~pad:false ~alphabet:Base64.uri_safe_alphabet
+      Base64.encode_exn ~pad:false ~alphabet:Base64.uri_safe_alphabet str
     in
     { kty = `oct; alg = `HS256; kid = Util.get_OCT_kid ~k; k }
 end

--- a/jose/Jwk.ml
+++ b/jose/Jwk.ml
@@ -27,18 +27,7 @@ module Util = struct
     |> Base64.encode ~pad:false ~alphabet:Base64.uri_safe_alphabet ~len:20
 end
 
-module Pub = struct
-  (*
-  TODO: Implement EC
-  {
-    "kty":"EC",
-    "crv":"P-256",
-    "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
-    "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
-    "d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"
-  }
-  *)
-
+module Oct = struct
   type oct = {
     kty : Jwa.kty;
     (* `oct *)
@@ -55,6 +44,21 @@ module Pub = struct
       |> Base64.encode_exn ~pad:false ~alphabet:Base64.uri_safe_alphabet
     in
     { kty = `oct; alg = `HS256; kid = Util.get_OCT_kid ~k; k }
+end
+
+module Pub = struct
+  include Oct
+
+  (*
+  TODO: Implement EC
+  {
+    "kty":"EC",
+    "crv":"P-256",
+    "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+    "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+    "d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"
+  }
+  *)
 
   type rsa = {
     alg : Jwa.alg;
@@ -208,14 +212,7 @@ module Pub = struct
 end
 
 module Priv = struct
-  type oct = {
-    kty : Jwa.kty;
-    (* `oct *)
-    alg : Jwa.alg;
-    (* `HS256 *)
-    kid : string;
-    k : string;
-  }
+  include Oct
 
   type rsa = {
     alg : Jwa.alg;

--- a/test/jose/JWTTest.re
+++ b/test/jose/JWTTest.re
@@ -55,10 +55,7 @@ describe("JWT", ({test}) => {
       Jwt.sign(~header, ~payload, Jwk.Priv.RSA(Fixtures.private_jwk))
       |> CCResult.get_exn;
 
-    expect.string(
-      jwt |> CCResult.flat_map(Jwt.to_string) |> CCResult.get_exn,
-    ).
-      toEqual(
+    expect.string(jwt |> Jwt.to_string |> CCResult.get_exn).toEqual(
       Fixtures.external_jwt_string,
     );
   });

--- a/test/jose/JWTTest.re
+++ b/test/jose/JWTTest.re
@@ -52,11 +52,7 @@ describe("JWT", ({test}) => {
     let payload =
       Jwt.empty_payload |> Jwt.add_claim("sub", `String("tester"));
     let jwt =
-      Jwt.sign(
-        ~header,
-        ~payload,
-        Fixtures.private_jwk |> Jwk.Priv.rsa_to_priv |> CCResult.get_exn,
-      );
+      Jwt.sign(~header, ~payload, Fixtures.private_jwk) |> CCResult.get_exn;
 
     expect.string(
       jwt |> CCResult.flat_map(Jwt.to_string) |> CCResult.get_exn,
@@ -71,12 +67,7 @@ describe("JWT", ({test}) => {
     let payload =
       Jwt.empty_payload |> Jwt.add_claim("sub", `String("tester"));
     let jwt =
-      Jwt.sign(
-        ~header,
-        ~payload,
-        Fixtures.private_jwk |> Jwk.Priv.rsa_to_priv |> CCResult.get_exn,
-      )
-      |> CCResult.get_exn;
+      Jwt.sign(~header, ~payload, Fixtures.private_jwk) |> CCResult.get_exn;
 
     expect.result(Jwt.validate(~jwk=Jwk.Pub.RSA(Fixtures.public_jwk), jwt)).
       toBeOk();

--- a/test/jose/JWTTest.re
+++ b/test/jose/JWTTest.re
@@ -52,7 +52,8 @@ describe("JWT", ({test}) => {
     let payload =
       Jwt.empty_payload |> Jwt.add_claim("sub", `String("tester"));
     let jwt =
-      Jwt.sign(~header, ~payload, Fixtures.private_jwk) |> CCResult.get_exn;
+      Jwt.sign(~header, ~payload, Jwk.Priv.RSA(Fixtures.private_jwk))
+      |> CCResult.get_exn;
 
     expect.string(
       jwt |> CCResult.flat_map(Jwt.to_string) |> CCResult.get_exn,
@@ -67,7 +68,8 @@ describe("JWT", ({test}) => {
     let payload =
       Jwt.empty_payload |> Jwt.add_claim("sub", `String("tester"));
     let jwt =
-      Jwt.sign(~header, ~payload, Fixtures.private_jwk) |> CCResult.get_exn;
+      Jwt.sign(~header, ~payload, Jwk.Priv.RSA(Fixtures.private_jwk))
+      |> CCResult.get_exn;
 
     expect.result(Jwt.validate(~jwk=Jwk.Pub.RSA(Fixtures.public_jwk), jwt)).
       toBeOk();


### PR DESCRIPTION
The only weirdness with this patch right now is that you need to create 2 keys with the same secret for HS256:

```ocaml
let secret = Jwk.Priv.OCT (Jwk.Priv.oct_of_string "123")

let pub_secret = Jwk.Pub.OCT (Jwk.Pub.oct_of_string "123")

let encode_and_sign payload =
  let header = Header.make_header ~typ:"JWT" pub_secret in
  Jwt.sign ~header ~payload secret
```

This can probably be made better in a future patch.