### PR TITLE
RFC 7638: Implement thumbprints

### DIFF
--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -119,7 +119,7 @@ module Jwk : sig
       | `Missing_use_and_alg ] )
     result
   (**
-    [of_pub_json t] takes a [Yojson.Safe.t] and tries to return a [public t] 
+    [of_pub_json t] takes a [Yojson.Safe.t] and tries to return a [public t]
     *)
 
   val of_pub_json_string :
@@ -218,6 +218,14 @@ module Jwk : sig
 
   val get_alg : 'a t -> Jwa.alg
   (** [get_alg jwk] is a convencience function to get the algorithm *)
+
+  val get_thumbprint :
+    Mirage_crypto.Hash.hash -> 'a t -> (string, [> `Unsafe ]) result
+  (** [get_thumbprint hash jwk] calculates the thumbprint of [jwk] with
+      [hash], following {{: https://tools.ietf.org/html/rfc7638 } RFC 7638 }.
+
+      Returns an error for symmetric keys: sharing the hash may leak
+      information about the key itself ans it's deemed unsafe. *)
 
   val use_to_string : use -> string
 

--- a/test/Fixtures.ml
+++ b/test/Fixtures.ml
@@ -76,6 +76,20 @@ let public_jwk_string =
 "use": "sig",
 "x5t":"LiE8S21-GUjC1x4er0S9g76rYbQ"}|}
 
+let public_jwk_string_rfc_7638 =
+  {|{
+"kty": "RSA",
+"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+"e": "AQAB",
+"alg": "RS256",
+"kid": "2011-04-29"}|}
+
+let public_jwk_string_rfc_7638_hashable =
+  {|{"e":"AQAB","kty":"RSA","n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"}|}
+
+let public_jwk_string_rfc_7638_hashed =
+  {|NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs|}
+
 let external_jwt_string =
   {|eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjBJUkZOX1JVSFVRY1hjZHBfN1BMQnhvR185YjZiSHJ2R0gwcDhxUm90aWsifQ.eyJzdWIiOiJ0ZXN0ZXIifQ.Jl9BJyYkLW5sHXpmxM4VNA9IEVFxTKkqWw4TkXBfj02xuLGY4cYKz_IlLEBeUN-mHGEJ8hiJMhaybBI2OM2FBahK-csLgjVuPBAznsGVsW6wAWZR47AeoBLr8uh09IYbEpHvqA_aIBdM5pvgM9_t3VtC9L50944HmTcmOkGR9BzaINk33ubYIgkXfClVNzTXc5PiD6haJqhPRb6XS5UZQOHIhyTtJ3gl1NX0LEBRH5ZsgEe_5L8ZNSoAcBFnuS-XMTy7Z4PacBtZG9Y8NHh90K45WTeS7pQw6GR-AQsrrkW-xkDMF_79qJkvVPU6UneaJjMtQctki1RDRZWF32I5mQ|}
 

--- a/test/Helpers.ml
+++ b/test/Helpers.ml
@@ -8,7 +8,8 @@ let result_t :
     | `Missing_use_and_alg
     | `Invalid_JWE
     | `Invalid_JWK
-    | `Decrypt_cek_failed ]
+    | `Decrypt_cek_failed
+    | `Unsafe ]
     Alcotest.testable =
   let pp ppf = function
     | `Msg e -> Fmt.string ppf e
@@ -21,6 +22,7 @@ let result_t :
     | `Invalid_JWE -> Fmt.string ppf "Invalid JWE"
     | `Invalid_JWK -> Fmt.string ppf "Invalid JWK"
     | `Decrypt_cek_failed -> Fmt.string ppf "Failed to decrypt cek"
+    | `Unsafe -> Fmt.string ppf "Unsafe"
   in
   Alcotest.testable pp ( = )
 
@@ -36,3 +38,5 @@ let check_int = Alcotest.(check int)
 
 let trim_json_string str =
   str |> CCString.replace ~sub:" " ~by:"" |> CCString.replace ~sub:"\n" ~by:""
+
+let make_test_case (name, test) = Alcotest.test_case name `Quick test

--- a/test/RFC7638.ml
+++ b/test/RFC7638.ml
@@ -1,0 +1,54 @@
+open Helpers
+module Jwk = Jose.Jwk
+
+let get_thumbprint jwk = Jwk.get_thumbprint `SHA256 jwk
+
+let get_ok_thumbprint jwk = get_thumbprint jwk |> CCResult.get_exn
+
+let public_rsa_thumbprint () =
+  let hashable_reference =
+    Fixtures.public_jwk_string_rfc_7638_hashable |> Cstruct.of_string
+    |> Mirage_crypto.Hash.SHA256.digest |> Cstruct.to_string
+  in
+  let hashed_reference =
+    Fixtures.public_jwk_string_rfc_7638_hashed
+    |> Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet
+    |> CCResult.get_exn
+  in
+  let thumbprint =
+    Fixtures.public_jwk_string_rfc_7638 |> Jwk.of_pub_json_string
+    |> CCResult.get_exn |> get_ok_thumbprint
+  in
+  check_string "Hashes must match" hashable_reference thumbprint;
+  check_string "Hashes must match" hashed_reference thumbprint
+
+let private_rsa_thumbprint () =
+  let private_thumbprint =
+    Fixtures.private_jwk_string |> Jwk.of_priv_json_string |> CCResult.get_exn
+    |> get_ok_thumbprint
+  in
+  let public_thumbprint =
+    Fixtures.public_jwk_string |> Jwk.of_pub_json_string |> CCResult.get_exn
+    |> get_ok_thumbprint
+  in
+  check_string "Hashes must match" public_thumbprint private_thumbprint
+
+let symmetric_thumbprint () =
+  let jwk =
+    Fixtures.oct_jwk_string |> Jwk.of_pub_json_string |> CCResult.get_exn
+  in
+  check_result_string "Errors must match" (Error `Unsafe) (get_thumbprint jwk)
+
+let tests =
+  List.map make_test_case
+    [
+      ( "Correct fields are used from public RSA key to generate thumbprint",
+        public_rsa_thumbprint );
+      ( "Thumbprint from a private RSA key and its public key are the same",
+        private_rsa_thumbprint );
+      ("Thumbprint for symmetric keys is never calculated", symmetric_thumbprint);
+    ]
+
+let suite, _ =
+  Junit_alcotest.run_and_report ~package:"jose" "RFC7638"
+    [ ("RFC 7638", tests) ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -8,6 +8,7 @@ let () =
         JWTTest.jwt_suite;
         JWETest.jwe_suite;
         RFC7520.suite;
+        RFC7638.suite;
       ]
   in
   match path with Some path -> Junit.to_file report path | None -> ()


### PR DESCRIPTION
I used the example in the RFC for the tests on the public RSA key. The private one was also easy to test, but couldn't find a test for the symmetric key.