### PR TITLE
Cstruct thumbprint

### DIFF
--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -196,7 +196,7 @@ module Jwk : sig
   (** [get_alg jwk] is a convencience function to get the algorithm *)
 
   val get_thumbprint :
-    Mirage_crypto.Hash.hash -> 'a t -> (string, [> `Unsafe ]) result
+    Mirage_crypto.Hash.hash -> 'a t -> (Cstruct.t, [> `Unsafe ]) result
   (** [get_thumbprint hash jwk] calculates the thumbprint of [jwk] with [hash],
       following {{: https://tools.ietf.org/html/rfc7638 } RFC 7638 }.
 

--- a/jose/Jwk.ml
+++ b/jose/Jwk.ml
@@ -688,7 +688,7 @@ let oct_to_sign_key (oct : oct) : (Cstruct.t, [> `Msg of string ]) result =
 let hash_values hash values =
   let module Hash = (val Mirage_crypto.Hash.module_of hash) in
   `Assoc (U_List.filter_map (fun x -> x) values)
-  |> Yojson.to_string |> Cstruct.of_string |> Hash.digest |> Cstruct.to_string
+  |> Yojson.to_string |> Cstruct.of_string |> Hash.digest
 
 let pub_rsa_to_thumbprint hash (pub_rsa : Mirage_crypto_pk.Rsa.pub jwk) =
   let e = Util.get_JWK_component pub_rsa.key.e in
@@ -697,7 +697,7 @@ let pub_rsa_to_thumbprint hash (pub_rsa : Mirage_crypto_pk.Rsa.pub jwk) =
   let values =
     [ Some ("e", `String e); Some ("kty", `String kty); Some ("n", `String n) ]
   in
-  hash_values hash values |> U_Base64.url_encode_string
+  hash_values hash values
 
 let priv_rsa_to_thumbprint hash (priv_rsa : Mirage_crypto_pk.Rsa.priv jwk) =
   pub_rsa_to_thumbprint hash (pub_of_priv_rsa priv_rsa)
@@ -716,7 +716,7 @@ let pub_es256_to_thumbprint hash (pub_es256 : pub_es256) =
       Some ("y", `String y);
     ]
   in
-  hash_values hash values |> U_Base64.url_encode_string
+  hash_values hash values
 
 let priv_es256_to_thumbprint hash (priv_es256 : priv_es256) =
   pub_of_priv_es256 priv_es256 |> pub_es256_to_thumbprint hash
@@ -733,7 +733,7 @@ let pub_es512_to_thumbprint hash (pub_es512 : pub_es512) =
       Some ("y", `String y);
     ]
   in
-  hash_values hash values |> U_Base64.url_encode_string
+  hash_values hash values
 
 let priv_es512_to_thumbprint hash (priv_es512 : priv_es512) =
   pub_of_priv_es512 priv_es512 |> pub_es512_to_thumbprint hash

--- a/test/Helpers.ml
+++ b/test/Helpers.ml
@@ -43,3 +43,9 @@ let trim_json_string str =
   str |> CCString.replace ~sub:" " ~by:"" |> CCString.replace ~sub:"\n" ~by:""
 
 let make_test_case (name, test) = Alcotest.test_case name `Quick test
+
+let url_encode_string ?(pad = false) payload =
+  Base64.encode_string ~pad ~alphabet:Base64.uri_safe_alphabet payload
+
+let url_encode_cstruct payload =
+  payload |> Cstruct.to_string |> url_encode_string

--- a/test/JWKTest.ml
+++ b/test/JWKTest.ml
@@ -169,6 +169,7 @@ let jwk_suite, _ =
               in
               check_result_string "Creates the correct thumbprint"
                 (Ok "ZrBaai73Hi8Fg4MElvDGzIne2NsbI75RHubOViHYE5Q")
+              @@ Result.map url_encode_cstruct
               @@ Jose.Jwk.get_thumbprint `SHA256 pub_jwk);
           Alcotest.test_case "P256 - thumbprint" `Quick (fun () ->
               let pub_string =
@@ -184,6 +185,7 @@ let jwk_suite, _ =
               in
               check_result_string "Creates the correct thumbprint"
                 (Ok "nBBpbUsITZuECZH0WpBqPH4HKwYV3Tx2KDVyNfwvOkU")
+              @@ Result.map url_encode_cstruct
               @@ Jose.Jwk.get_thumbprint `SHA256 pub_jwk);
         ] );
     ]


### PR DESCRIPTION
Fixes #43

There' some duplicated code after this that should be removed to use the same implementation as thumbprint.